### PR TITLE
Upgrade Airline experiment to GPflow 2

### DIFF
--- a/VFF/__init__.py
+++ b/VFF/__init__.py
@@ -11,10 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-
-from .gpmc import GPMC_1d, GPMC_kron
-from .vgp import VGP_1d, VGP_kron, VGP_additive
-from .gpr import GPR_1d, GPR_additive
-
-from .ssgp import SSGP

--- a/VFF/gpr.py
+++ b/VFF/gpr.py
@@ -13,124 +13,40 @@
 # limitations under the License.
 
 
-from __future__ import print_function, absolute_import
-import numpy as np
-import gpflow
-import tensorflow as tf
 from functools import reduce
-from .spectral_covariance import make_Kuu, make_Kuf, make_Kuf_np
-from .kronecker_ops import kron, make_kvs_np, make_kvs
+
+import numpy as np
+import tensorflow as tf
+
+import gpflow
+from gpflow.utilities import to_default_float
+
+
 from .matrix_structures import BlockDiagMat_many
-from gpflow import settings
-float_type = settings.dtypes.float_type
+from .spectral_covariance import make_Kuf, make_Kuf_np, make_Kuu
 
 
-class GPR_1d(gpflow.models.GPModel):
-    def __init__(self, X, Y, ms, a, b, kern):
-        assert X.shape[1] == 1
-        assert isinstance(kern, (gpflow.kernels.Matern12,
-                                 gpflow.kernels.Matern32,
-                                 gpflow.kernels.Matern52))
-        likelihood = gpflow.likelihoods.Gaussian()
+class GPR_additive(gpflow.models.GPR):
+
+    def __init__(self, data, ms, a, b, kernels):
+        X, Y = data
+        assert X.shape[1] == len(kernels)
+        assert a.size == len(kernels)
+        assert b.size == len(kernels)
+        # Check that the type of each kernel belongs to the Matern family
+        assert all(map(lambda k: "Matern" in type(k).__name__, kernels))
+
         mean_function = gpflow.mean_functions.Zero()
-        gpflow.models.GPModel.__init__(self, X, Y, kern,
-                                      likelihood, mean_function)
+        super().__init__(data, kernels, mean_function)
+
+        self.X, self.Y = data
         self.num_data = X.shape[0]
         self.num_latent = Y.shape[1]
         self.a = a
         self.b = b
         self.ms = ms
-
-        # pre compute static quantities
-        assert np.all(X > a)
-        assert np.all(X < b)
-        Kuf = make_Kuf_np(X, a, b, ms)
-        self.KufY = np.dot(Kuf, Y)
-        self.KufKfu = np.dot(Kuf, Kuf.T)
-        self.tr_YTY = np.sum(np.square(Y))
-
-    @gpflow.params_as_tensors
-    def _build_likelihood(self):
-        return reduce(tf.add, self.build_likelihood_terms())
-
-    def build_likelihood_terms(self):
-        Kdiag = self.kern.Kdiag(self.X)
-        Kuu = make_Kuu(self.kern, self.a, self.b, self.ms)
-        sigma2 = self.likelihood.variance
-
-        # Compute intermediate matrices
-        P = self.KufKfu / sigma2 + Kuu.get()
-        L = tf.cholesky(P)
-        log_det_P = tf.reduce_sum(tf.log(tf.square(tf.diag_part(L))))
-        c = tf.matrix_triangular_solve(L, self.KufY) / sigma2
-
-        # compute log marginal bound
-        ND = tf.cast(tf.size(self.Y), float_type)
-        D = tf.cast(tf.shape(self.Y)[1], float_type)
-        return (-0.5 * ND * tf.log(2 * np.pi * sigma2),
-                -0.5 * D * log_det_P,
-                0.5 * D * Kuu.logdet(),
-                -0.5 * self.tr_YTY / sigma2,
-                0.5 * tf.reduce_sum(tf.square(c)),
-                -0.5 * tf.reduce_sum(Kdiag)/sigma2,
-                0.5 * Kuu.trace_KiX(self.KufKfu) / sigma2)
-
-    @gpflow.autoflow()
-    def compute_likelihood_terms(self):
-        return self.build_likelihood_terms()
-
-    @gpflow.params_as_tensors
-    def _build_predict(self, Xnew, full_cov=False):
-        Kuu = make_Kuu(self.kern, self.a, self.b, self.ms)
-        sigma2 = self.likelihood.variance
-
-        # Compute intermediate matrices
-        P = self.KufKfu / sigma2 + Kuu.get()
-        L = tf.cholesky(P)
-        c = tf.matrix_triangular_solve(L, self.KufY) / sigma2
-
-        Kus = make_Kuf(self.kern, Xnew, self.a, self.b, self.ms)
-        tmp = tf.matrix_triangular_solve(L, Kus)
-        mean = tf.matmul(tf.transpose(tmp), c)
-        KiKus = Kuu.solve(Kus)
-        if full_cov:
-            var = self.kern.k(Xnew) + \
-               tf.matmul(tf.transpose(tmp), tmp) - \
-               tf.matmul(tf.transpose(KiKus), Kus)
-            shape = tf.stack([1, 1, tf.shape(self.y)[1]])
-            var = tf.tile(tf.expand_dims(var, 2), shape)
-        else:
-            var = self.kern.Kdiag(Xnew)
-            var += tf.reduce_sum(tf.square(tmp), 0)
-            var -= tf.reduce_sum(KiKus * Kus, 0)
-            shape = tf.stack([1, tf.shape(self.Y)[1]])
-            var = tf.tile(tf.expand_dims(var, 1), shape)
-        return mean, var
-
-
-class GPR_additive(gpflow.models.GPModel):
-    def __init__(self, X, Y, ms, a, b, kern_list):
-        assert X.shape[1] == len(kern_list)
-        assert a.size == len(kern_list)
-        assert b.size == len(kern_list)
-        for kern in kern_list:
-            assert isinstance(kern, (gpflow.kernels.Matern12,
-                                     gpflow.kernels.Matern32,
-                                     gpflow.kernels.Matern52))
-        likelihood = gpflow.likelihoods.Gaussian()
-        mean_function = gpflow.mean_functions.Zero()
-        gpflow.models.GPModel.__init__(self, X, Y, None,
-                                      likelihood, mean_function)
-        self.num_data = X.shape[0]
-        self.num_latent = Y.shape[1]
-        self.a = a
-        self.b = b
-        self.ms = ms
-
-        self.kerns = gpflow.ParamList(kern_list)
 
         # pre compute static quantities: chunk data to save memory
-        self.tr_YTY = gpflow.DataHolder(np.sum(np.square(Y)))
         Mtotal = (2*self.ms.size - 1) * X.shape[1]
         self.KufY = np.zeros((Mtotal, 1))
         self.KufKfu = np.zeros((Mtotal, Mtotal))
@@ -147,29 +63,31 @@ class GPR_additive(gpflow.models.GPModel):
                 Kuf_chunk = np.vstack((Kuf_chunk, Kuf))
             self.KufKfu += np.dot(Kuf_chunk, Kuf_chunk.T)
             self.KufY += KufY_chunk
-        self.KufY = gpflow.DataHolder(self.KufY)
-        self.KufKfu = gpflow.DataHolder(self.KufKfu)
 
-    @gpflow.params_as_tensors
-    def _build_likelihood(self):
-        num_data = tf.shape(self.Y)[0]
-        output_dim = tf.shape(self.Y)[1]
+        self.tr_YTY = tf.convert_to_tensor(np.sum(np.square(Y)))
+        self.KufY = tf.convert_to_tensor(self.KufY)
+        self.KufKfu = tf.convert_to_tensor(self.KufKfu)
+    
+    def log_marginal_likelihood(self):
+        X, Y = self.data
+        num_data = tf.shape(Y)[0]
+        output_dim = tf.shape(Y)[1]
 
-        total_variance = reduce(tf.add, [k.variance for k in self.kerns])
-        Kuu = [make_Kuu(k, ai, bi, self.ms) for k, ai, bi in zip(self.kerns, self.a, self.b)]
+        total_variance = reduce(tf.add, [k.variance for k in self.kernel])
+        Kuu = [make_Kuu(k, ai, bi, self.ms) for k, ai, bi in zip(self.kernel, self.a, self.b)]
         Kuu = BlockDiagMat_many([mat for k in Kuu for mat in [k.A, k.B]])
         sigma2 = self.likelihood.variance
 
         # Compute intermediate matrices
         P = self.KufKfu / sigma2 + Kuu.get()
-        L = tf.cholesky(P)
-        log_det_P = tf.reduce_sum(tf.log(tf.square(tf.diag_part(L))))
-        c = tf.matrix_triangular_solve(L, self.KufY) / sigma2
+        L = tf.linalg.cholesky(P)
+        log_det_P = tf.reduce_sum(tf.math.log(tf.square(tf.linalg.diag_part(L))))
+        c = tf.linalg.triangular_solve(L, self.KufY) / sigma2
 
         # compute log marginal bound
-        ND = tf.cast(num_data * output_dim, float_type)
-        D = tf.cast(output_dim, float_type)
-        bound = -0.5 * ND * tf.log(2 * np.pi * sigma2)
+        ND = to_default_float(num_data * output_dim)
+        D = to_default_float(output_dim)
+        bound = -0.5 * ND * tf.math.log(2 * np.pi * sigma2)
         bound += -0.5 * D * log_det_P
         bound += 0.5 * D * Kuu.logdet()
         bound += -0.5 * self.tr_YTY / sigma2
@@ -179,165 +97,35 @@ class GPR_additive(gpflow.models.GPModel):
 
         return bound
 
-    @gpflow.params_as_tensors
-    def _build_predict(self, Xnew, full_cov=False):
-        Kuu = [make_Kuu(k, ai, bi, self.ms) for k, ai, bi in zip(self.kerns, self.a, self.b)]
+    def predict_f(self, Xnew, full_cov=False, full_output_cov=False):
+        assert not full_output_cov
+
+        Kuu = [make_Kuu(k, ai, bi, self.ms) for k, ai, bi in zip(self.kernel, self.a, self.b)]
         Kuu = BlockDiagMat_many([mat for k in Kuu for mat in [k.A, k.B]])
         sigma2 = self.likelihood.variance
 
         # Compute intermediate matrices
         P = self.KufKfu / sigma2 + Kuu.get()
-        L = tf.cholesky(P)
-        c = tf.matrix_triangular_solve(L, self.KufY) / sigma2
+        L = tf.linalg.cholesky(P)
+        c = tf.linalg.triangular_solve(L, self.KufY) / sigma2
 
-        Kus = tf.concat([make_Kuf(k, Xnew[:, i:i+1], a, b, self.ms)
-                         for i, (k, a, b) in enumerate(zip(self.kerns, self.a, self.b))], axis=0)
-        tmp = tf.matrix_triangular_solve(L, Kus)
-        mean = tf.matmul(tf.transpose(tmp), c)
+        values = [
+            make_Kuf(k, Xnew[:, i:i+1], a, b, self.ms)
+            for i, (k, a, b) in enumerate(zip(self.kernel, self.a, self.b))
+        ]
+        Kus = tf.concat(values, axis=0)
+        tmp = tf.linalg.triangular_solve(L, Kus)
+        # bla
+        mean = tf.matmul(tmp, c, transpose_a=True)
         KiKus = Kuu.solve(Kus)
         if full_cov:
-            var = reduce(tf.add, [k.K(Xnew[:, i:i+1]) for i, k in enumerate(self.kerns)])
+            var = reduce(tf.add, [k.K(Xnew[:, i:i+1]) for i, k in enumerate(self.kernel)])
             var += tf.matmul(tf.transpose(tmp), tmp)
             var -= tf.matmul(tf.transpose(KiKus), Kus)
             shape = tf.stack([1, 1, tf.shape(self.Y)[1]])
             var = tf.tile(tf.expand_dims(var, 2), shape)
         else:
-            var = reduce(tf.add, [k.Kdiag(Xnew[:, i:i+1]) for i, k in enumerate(self.kerns)])
-            var += tf.reduce_sum(tf.square(tmp), 0)
-            var -= tf.reduce_sum(KiKus * Kus, 0)
-            shape = tf.stack([1, tf.shape(self.Y)[1]])
-            var = tf.tile(tf.expand_dims(var, 1), shape)
-        return mean, var
-
-    @gpflow.autoflow((float_type, [None, 1]))
-    @gpflow.params_as_tensors
-    def predict_components(self, Xnew):
-        """
-        Here, Xnew should be a Nnew x 1 array of points at which to test each function
-        """
-        Kuu = [make_Kuu(k, ai, bi, self.ms) for k, ai, bi in zip(self.kerns, self.a, self.b)]
-        Kuu = BlockDiagMat_many([mat for k in Kuu for mat in [k.A, k.B]])
-        sigma2 = self.likelihood.variance
-
-        # Compute intermediate matrices
-        P = self.KufKfu / sigma2 + Kuu.get()
-        L = tf.cholesky(P)
-        c = tf.matrix_triangular_solve(L, self.KufY) / sigma2
-
-        Kus_blocks = [make_Kuf(k, Xnew, a, b, self.ms)
-                      for i, (k, a, b) in enumerate(zip(self.kerns, self.a, self.b))]
-        Kus = []
-        start = tf.constant(0, tf.int32)
-        for i, b in enumerate(Kus_blocks):
-            zeros_above = tf.zeros(tf.stack([start, tf.shape(b)[1]]), float_type)
-            zeros_below = tf.zeros(tf.stack([tf.shape(L)[0] - start - tf.shape(b)[0], tf.shape(b)[1]]), float_type)
-            Kus.append(tf.concat([zeros_above, b, zeros_below], axis=0))
-            start = start + tf.shape(b)[0]
-
-        tmp = [tf.matrix_triangular_solve(L, Kus_i) for Kus_i in Kus]
-        mean = [tf.matmul(tf.transpose(tmp_i), c) for tmp_i in tmp]
-        KiKus = [Kuu.solve(Kus_i) for Kus_i in Kus]
-        var = [k.Kdiag(Xnew[:, i:i+1]) for i, k in enumerate(self.kerns)]
-        var = [v + tf.reduce_sum(tf.square(tmp_i), 0) for v, tmp_i in zip(var, tmp)]
-        var = [v - tf.reduce_sum(KiKus_i * Kus_i, 0) for v, KiKus_i, Kus_i in zip(var, KiKus, Kus)]
-        var = [tf.expand_dims(v, 1) for v in var]
-        return tf.concat(mean, axis=1), tf.concat(var, axis=1)
-
-
-class GPRKron(gpflow.models.GPModel):
-    def __init__(self, X, Y, ms, a, b, kerns):
-        for kern in kerns:
-            assert isinstance(kern, (gpflow.kernels.Matern12,
-                                     gpflow.kernels.Matern32,
-                                     gpflow.kernels.Matern52))
-        likelihood = gpflow.likelihoods.Gaussian()
-        mean_function = gpflow.mean_functions.Zero()
-        gpflow.models.GPModel.__init__(self, X, Y, None,
-                                      likelihood, mean_function)
-        self.kerns = gpflow.ParamList(kerns)
-        self.num_data = X.shape[0]
-        self.num_latent = Y.shape[1]
-        self.a = a
-        self.b = b
-        self.ms = ms
-
-        # count the inducing variables:
-        self.Ms = []
-        for kern in kerns:
-            Ncos_d = self.ms.size
-            Nsin_d = self.ms.size - 1
-            self.Ms.append(Ncos_d + Nsin_d)
-
-        assert np.all(X > a)
-        assert np.all(X < b)
-
-        # pre compute static quantities
-        Kuf = [make_Kuf_np(X[:, i:i+1], a, b, self.ms)
-               for i, (a, b) in enumerate(zip(self.a, self.b))]
-        self.Kuf = make_kvs_np(Kuf)
-        self.KufY = np.dot(self.Kuf, Y)
-        self.KufKfu = np.dot(self.Kuf, self.Kuf.T)
-        self.tr_YTY = np.sum(np.square(Y))
-
-    @gpflow.params_as_tensors
-    def _build_likelihood(self):
-        return reduce(tf.add, self.build_likelihood_terms())
-
-    @gpflow.params_as_tensors
-    def _build_likelihood_terms(self):
-        Kdiag = reduce(tf.multiply, [k.Kdiag(self.X[:, i:i+1]) for i, k in enumerate(self.kerns)])
-        Kuu = [make_Kuu(k, a, b, self.ms) for k, a, b, in zip(self.kerns, self.a, self.b)]
-        Kuu_solid = kron([Kuu_d.get() for Kuu_d in Kuu])
-        Kuu_inv_solid = kron([Kuu_d.inv().get() for Kuu_d in Kuu])
-        sigma2 = self.likelihood.variance
-
-        # Compute intermediate matrices
-        P = self.KufKfu / sigma2 + Kuu_solid
-        L = tf.cholesky(P)
-        log_det_P = tf.reduce_sum(tf.log(tf.square(tf.diag_part(L))))
-        c = tf.matrix_triangular_solve(L, self.KufY) / sigma2
-
-        Kuu_logdets = [K.logdet() for K in Kuu]
-        N_others = [float(np.prod(self.Ms)) / M for M in self.Ms]
-        Kuu_logdet = reduce(tf.add, [N*logdet for N, logdet in zip(N_others, Kuu_logdets)])
-
-        # compute log marginal bound
-        ND = tf.cast(tf.size(self.Y), float_type)
-        D = tf.cast(tf.shape(self.Y)[1], float_type)
-        return (-0.5 * ND * tf.log(2 * np.pi * sigma2),
-                -0.5 * D * log_det_P,
-                0.5 * D * Kuu_logdet,
-                -0.5 * self.tr_YTY / sigma2,
-                0.5 * tf.reduce_sum(tf.square(c)),
-                -0.5 * tf.reduce_sum(Kdiag)/sigma2,
-                0.5 * tf.reduce_sum(Kuu_inv_solid * self.KufKfu) / sigma2)
-
-    @gpflow.autoflow()
-    def compute_likelihood_terms(self):
-        return self.build_likelihood_terms()
-
-    @gpflow.params_as_tensors
-    def _build_predict(self, Xnew, full_cov=False):
-        Kuu = [make_Kuu(k, a, b, self.ms) for k, a, b, in zip(self.kerns, self.a, self.b)]
-        Kuu_solid = kron([Kuu_d.get() for Kuu_d in Kuu])
-        Kuu_inv_solid = kron([Kuu_d.inv().get() for Kuu_d in Kuu])
-        sigma2 = self.likelihood.variance
-
-        # Compute intermediate matrices
-        P = self.KufKfu / sigma2 + Kuu_solid
-        L = tf.cholesky(P)
-        c = tf.matrix_triangular_solve(L, self.KufY) / sigma2
-
-        Kus = [make_Kuf(k, Xnew[:, i:i+1], a, b, self.ms)
-               for i, (k, a, b) in enumerate(zip(self.kerns, self.a, self.b))]
-        Kus = tf.transpose(make_kvs([tf.transpose(Kus_d) for Kus_d in Kus]))
-        tmp = tf.matrix_triangular_solve(L, Kus)
-        mean = tf.matmul(tf.transpose(tmp), c)
-        KiKus = tf.matmul(Kuu_inv_solid, Kus)
-        if full_cov:
-            raise NotImplementedError
-        else:
-            var = reduce(tf.multiply, [k.Kdiag(Xnew[:, i:i+1]) for i, k in enumerate(self.kerns)])
+            var = reduce(tf.add, [k.K_diag(Xnew[:, i:i+1]) for i, k in enumerate(self.kernel)])
             var += tf.reduce_sum(tf.square(tmp), 0)
             var -= tf.reduce_sum(KiKus * Kus, 0)
             shape = tf.stack([1, tf.shape(self.Y)[1]])

--- a/VFF/matrix_structures.py
+++ b/VFF/matrix_structures.py
@@ -14,11 +14,12 @@
 
 
 import tensorflow as tf
-from gpflow import settings
 from functools import reduce
-float_type = settings.dtypes.float_type
+import gpflow
 import numpy as np
 
+
+float_type = gpflow.config.default_float()
 
 class BlockDiagMat_many:
     def __init__(self, mats):
@@ -202,10 +203,10 @@ class LowRankMat:
         return tf.diag(self.d) + tf.matmul(self.W, tf.transpose(self.W))
 
     def logdet(self):
-        part1 = tf.reduce_sum(tf.log(self.d))
+        part1 = tf.reduce_sum(tf.math.log(self.d))
         I = tf.eye(tf.shape(self.W)[1], float_type)
         M = I + tf.matmul(tf.transpose(self.W) / self.d, self.W)
-        part2 = 2*tf.reduce_sum(tf.log(tf.diag_part(tf.cholesky(M))))
+        part2 = 2*tf.reduce_sum(tf.math.log(tf.diag_part(tf.cholesky(M))))
         return part1 + part2
 
     def matmul(self, B):
@@ -327,11 +328,11 @@ class Rank1Mat:
 
     def get(self):
         V = tf.expand_dims(self.v, 1)
-        return tf.diag(self.d) + tf.matmul(V, tf.transpose(V))
+        return tf.linalg.diag(self.d) + tf.matmul(V, tf.transpose(V))
 
     def logdet(self):
-        return tf.reduce_sum(tf.log(self.d)) +\
-            tf.log(1. + tf.reduce_sum(tf.square(self.v) / self.d))
+        return tf.reduce_sum(tf.math.log(self.d)) +\
+            tf.math.log(1. + tf.reduce_sum(tf.square(self.v) / self.d))
 
     def matmul(self, B):
         V = tf.expand_dims(self.v, 1)
@@ -361,7 +362,7 @@ class Rank1Mat:
         RTX = tf.matmul(tf.transpose(R), X)
         RTXR = tf.matmul(RTX, R)
         M = 1 + tf.reduce_sum(tf.square(self.v) / self.d)
-        return tf.reduce_sum(tf.diag_part(X) / self.d) - RTXR / M
+        return tf.reduce_sum(tf.linalg.diag_part(X) / self.d) - RTXR / M
 
     def get_diag(self):
         return self.d + tf.square(self.v)
@@ -415,7 +416,7 @@ class Rank1MatNeg:
 
     def get(self):
         W = tf.expand_dims(self.v, 1)
-        return tf.diag(self.d) - tf.matmul(W, tf.transpose(W))
+        return tf.linalg.diag(self.d) - tf.matmul(W, tf.transpose(W))
 
 
 class DiagMat:
@@ -431,10 +432,10 @@ class DiagMat:
         return tf.size(self.d)
 
     def get(self):
-        return tf.diag(self.d)
+        return tf.linalg.diag(self.d)
 
     def logdet(self):
-        return tf.reduce_sum(tf.log(self.d))
+        return tf.reduce_sum(tf.math.log(self.d))
 
     def matmul(self, B):
         return tf.expand_dims(self.d, 1) * B
@@ -450,7 +451,7 @@ class DiagMat:
         X is a square matrix of the same size as this one.
         if self is K, compute tr(K^{-1} X)
         """
-        return tf.reduce_sum(tf.diag_part(X) / self.d)
+        return tf.reduce_sum(tf.linalg.diag_part(X) / self.d)
 
     def get_diag(self):
         return self.d

--- a/VFF/spectral_covariance.py
+++ b/VFF/spectral_covariance.py
@@ -17,8 +17,8 @@ import numpy as np
 import gpflow
 import tensorflow as tf
 from .matrix_structures import DiagMat, Rank1Mat, LowRankMat, BlockDiagMat
-from gpflow import settings
-float_type = settings.dtypes.float_type
+
+float_type = gpflow.config.default_float()
 
 
 def make_Kuu(kern, a, b, ms):

--- a/experiments/banana/banana_plotting.py
+++ b/experiments/banana/banana_plotting.py
@@ -16,7 +16,7 @@
 import numpy as np
 from matplotlib import pyplot as plt
 from scipy.cluster.vq import kmeans
-import vff
+import VFF as vff
 import gpflow
 np.random.seed(0)
 
@@ -30,7 +30,8 @@ a = X.min(0) - 2.5
 b = X.max(0) + 2.5
 
 
-def plot(m, ax):
+def plot(model, ax):
+    m = model["model"]
     if ax is None:
         fig, ax = plt.subplots(1, 1, figsize=(6, 6))
     xtest, ytest = np.mgrid[-2.5:2.5:100j, -2.5:2.5:100j]
@@ -39,6 +40,8 @@ def plot(m, ax):
         ind = m.Y.value[:, 0] == i
         ax.plot(m.X.value[ind, 0], m.X.value[ind, 1], mark)
     mu, var = m.predict_y(Xtest)
+    model["predict_y_mean"] = mu
+    model["predict_y_var"] = var
     ax.contour(xtest, ytest, mu.reshape(100, 100), levels=[0.5],
                colors='C0', linewidths=4)
 
@@ -50,21 +53,23 @@ def plot(m, ax):
 models = []
 for M in [2, 4, 8, 16]:
     m = vff.vgp.VGP_kron(X, Y, np.arange(M), a=a, b=b, kerns=[k(1), k(1)], likelihood=lik(), use_two_krons=True)
-    models.append(m)
+    models.append({"model": m, "elbo": m.compute_log_likelihood()})
+    # models.append(m)
 
 # Pseudo-inputs
-for M in [4, 8, 16, 32]:
-    kern = k(1, active_dims=[0]) * k(1, active_dims=[1])
-    Z, _ = kmeans(X, M)
-    m = gpflow.models.SVGP(X, Y, kern=kern, likelihood=lik(), Z=Z)
-    models.append(m)
+# for M in [4, 8, 16, 32]:
+#     kern = k(1, active_dims=[0]) * k(1, active_dims=[1])
+#     Z, _ = kmeans(X, M)
+#     m = gpflow.models.SVGP(X, Y, kern=kern, likelihood=lik(), Z=Z)
+#     models.append(m)
 
-# full
-m = gpflow.models.VGP(X, Y, kern=k(1, active_dims=[0]) * k(1, active_dims=[1]), likelihood=lik())
-models.append(m)
+# # full
+# m = gpflow.models.VGP(X, Y, kern=k(1, active_dims=[0]) * k(1, active_dims=[1]), likelihood=lik())
+# models.append(m)
 
 ###############
 for m in models:
+    m = m["model"]
     try:
         o = gpflow.train.ScipyOptimizer()
         o.minimize(m)
@@ -72,11 +77,13 @@ for m in models:
         print('model optimization failed')
 
 ###############
-labels = ['VFF 2', 'VFF 4', 'VFF 8', 'VFF 16', 'IIP 4', 'IIP 8', 'IIP 16', 'IIP 32', 'Full']
+labels = ['VFF 2', 'VFF 4', 'VFF 8', 'VFF 16']  #, 'IIP 4', 'IIP 8', 'IIP 16', 'IIP 32', 'Full']
 f, axes = plt.subplots(3, 3, sharex=True, sharey=True, figsize=(15, 15))
 axes = axes.flatten()
 for ax, lab, m in zip(axes, labels, models):
+    m["name"] = lab
     plot(m, ax)
+    m = m["model"]
     ax.set_title(lab)
     if hasattr(m, 'Z'):
         ax.plot(m.Z.value[:, 0], m.Z.value[:, 1], 'ko', ms=4)
@@ -84,3 +91,9 @@ for ax, lab, m in zip(axes, labels, models):
 
 # m2t.save('banana_compare.tikz')
 plt.savefig('banana_compare.png')
+
+import pickle as pkl
+for m in models: del m["model"]  # only keep elbo, name, and predicts
+pkl.dump(models, open( f"results_vff_banana.pkl", "wb" ) )
+
+plt.show()


### PR DESCRIPTION
** DO NOT MERGE **

Hi all,
I spent a little bit of time updating the `GPR_additive` VFF model to GPflow 2 (`2.0.4`) and Tensorflow 2 (`2.2.0`) for the Airline experiment. IMPORTANT: I only updated the bits I needed for the Airline experiment, so this PR is very dirty and incomplete, but I still thought it could be useful for others. I would, however, not recommend merging this PR as it will leave the repo in a bad state.

I was able to exactly reproduce the MSE and NLPD given in the paper. The run times became significantly shorter. Experiment ran on a single 8GB GeForce GTX 1070 GPU and Intel i7-7700 CPU @ 3.60GHz CPU with 24 GB of RAM.
|                	| N    	| 10,000     	| 100,000    	| 1,000,000   	| 5,929,413   	|
|----------------	|------	|------------	|------------	|-------------	|-------------	|
|       MSE      	|      	|            	|            	|             	|             	|
|                	| mean 	| 0.89337489 	| 0.81916289 	|  0.83120151 	| 0.82781694  	|
|                	| std  	| 0.15461227 	| 0.05040159 	|  0.01323845 	| 0.00437594  	|
|      NLPD      	|      	|            	|            	|             	|             	|
|                	| mean 	| 1.36232179 	| 1.31913063 	|  1.32644348 	|   1.3244345 	|
|                	| std  	| 0.0906293  	| 0.03023875 	|  0.00791944 	|  0.00265458 	|
| Timing (clock) 	|      	|            	|            	|             	|             	|
|                	| mean 	| 18.3634206 	| 23.1457316 	| 58.2810024  	| 277.9453202 	|
|                	| std  	| 2.79274855 	| 2.39547268 	| 2.23852881  	| 2.93161274  	|
|  Timing (time) 	|      	|            	|            	|             	|             	|
|                	| mean 	| 6.78150756 	| 7.92476165 	| 17.44419279 	| 75.61273456 	|
|                	| std  	| 0.85582754 	| 0.4776275  	| 0.4343648   	| 0.75147633] 	|
   
